### PR TITLE
April 18 data: strucchange levels/trend

### DIFF
--- a/importData.R
+++ b/importData.R
@@ -1,0 +1,19 @@
+## Initial data import for strucchange
+
+# Import and label data table
+library(tidyverse); library(lubridate); library(stringr)
+aprData <- s3tools::s3_path_to_full_df("alpha-bjml-personalpractice/changeDetection/totalsApr18.csv") %>% as.tibble()
+colnames(aprData) <- c("Period", "totalTEW", "totalIO", "TOTAL")
+head(aprData)
+
+# Get Period into usable date format (defaulted to start of month)
+aprData$Period <- str_c("01 ", aprData$Period) # for Date reading
+aprData$PeriodStart <- as.Date(aprData$Period, "%d %b-%y")
+aprData$Period <- substr(aprData$Period,4,10) # revert col. 1
+head(aprData, 5); tail(aprData, 5)
+
+# Initial plot
+initGPlot <- ggplot(aprData, aes(PeriodStart, TOTAL)) + 
+  geom_line() +
+  labs(x = "Date", y = "Total Trials", title ="Total Trial Volume to April 2018")
+plot(initGPlot)

--- a/importData.R
+++ b/importData.R
@@ -17,3 +17,8 @@ initGPlot <- ggplot(aprData, aes(PeriodStart, TOTAL)) +
   geom_line() +
   labs(x = "Date", y = "Total Trials", title ="Total Trial Volume to April 2018")
 plot(initGPlot)
+
+# Set up timeseries
+tsAprTotal <- ts(aprData$TOTAL, frequency = 12, start = c(2008, 1), end = c(2018, 2))
+tsAprTEW <- ts(aprData$totalTEW, frequency = 12, start = c(2008, 1), end = c(2018, 2))
+tsAprIO <- ts(aprData$totalIO, frequency = 12, start = c(2008, 1), end = c(2018, 2))

--- a/main.R
+++ b/main.R
@@ -1,7 +1,7 @@
 ## Import April 18 CC data and display initial plot
-source('importData.R') # OUT: aprData tibble, totalTEW/totalIO/TOTAL monthly Jan01-Feb18
+source('importData.R') # OUT: aprData timeseries, use aprData.namesdict for dictionary of column names
 
-## TS Explore
+## TS Explore [NOT USED, WILL NOT WORK]
 plot(tsAprTotal)
 dcAprTotal <- decompose(tsAprTotal, type = "additive")
   plot(dcAprTotal)
@@ -10,7 +10,6 @@ fitApr <- ts(loess(aprData$TOTAL ~ tindex, span = 0.1)$fitted, frequency = 12, s
 plot(tsAprTotal); lines(fitApr, col  = 4)
 
 ## STRUCCHANGE // setup and useful functions
-packages.install("strucchange")
 library(strucchange)
 struccPlot <- function(tsData, brData, nBreak){
   # Displays chosen number of breaks on base timeseries datam with location error bars
@@ -30,23 +29,23 @@ brDates <- function(brData){
 }
 
 ## STRUCCHANGE// level breaks
-brAprTotal_l <- breakpoints(tsAprTotal ~ 1, h = 0.1) # ~1 is LEVELS
-summary(brAprTotal_l); plot(brAprTotal_l)
-struccPlot(tsAprTotal, brData = brAprTotal_l, nBreak = 4)
-
+column.choice <- "robbery.IO" # Choose offence type (name.short) from aprData.namesdict
+brApr.level <- breakpoints(aprData[,column.choice] ~ 1, h = 0.1) # ~1 is LEVELS
+summary(brApr.level); plot(brApr.level)
+struccPlot(aprData[,column.choice], brData = brApr.level, nBreak = 2)
 
 ## STRUCCHANGE // trend breaks
+column.choice <- column.choice # Option to change offence here
+tindex <- 1:length(aprData[,column.choice]) # Index times
+
 trend_fit <- lm(tsAprTotal ~ tindex) # linear model
   summary(trend_fit) # check LR model is signif
-brAprTotal_t <- breakpoints(tsAprTotal ~ tindex, h = 0.1) # ~ t is TREND (LR)
-summary(brAprTotal_t); plot(brAprTotal_t) # choose nBreak for min BIC
-struccPlot(tsAprTotal, brData = brAprTotal_t, nBreak = 2)
-brDates(breakdates(brAprTotal_t, breaks = 2))
-breakdates(brAprTotal_t, breaks = 2, format.times = TRUE)
-
-brAprTEW_t <- breakpoints(tsAprTEW ~ tindex, h = 0.1)
-summary(brAprTEW_t); plot(brAprTEW_t)
-struccPlot(tsAprTEW, brData = brAprTEW_t, nBreak=2)
+  
+brApr.trend <- breakpoints(aprData[,column.choice] ~ tindex, h = 0.1) # ~ t is TREND (LR)
+summary(brApr.trend); plot(brApr.trend) # choose nBreak for min BIC
+struccPlot(aprData[,column.choice], brData = brApr.trend, nBreak = 1)
+brDates(breakdates(brApr.trend, breaks = 1))
+breakdates(brApr.trend, breaks = 1, format.times = TRUE)
 
 ## STRUCCHANGE // polynomial fitting breaks
 # fit to 2o polynomial using lm(tsAprTotal ~ tt + I(tt^2))

--- a/main.R
+++ b/main.R
@@ -1,9 +1,8 @@
 ## Import April 18 CC data and display initial plot
-source('importData.R')
+source('importData.R') # OUT: aprData tibble, totalTEW/totalIO/TOTAL monthly Jan01-Feb18
 
 ## TS Explore
-tsAprTotal <- ts(aprData$TOTAL, frequency = 12, start = c(2008, 1), end = c(2018, 2))
-  plot(tsAprTotal)
+plot(tsAprTotal)
 dcAprTotal <- decompose(tsAprTotal, type = "additive")
   plot(dcAprTotal)
 tindex <- 1:length(aprData$TOTAL) # index times
@@ -11,33 +10,43 @@ fitApr <- ts(loess(aprData$TOTAL ~ tindex, span = 0.1)$fitted, frequency = 12, s
 plot(tsAprTotal); lines(fitApr, col  = 4)
 
 ## STRUCCHANGE // setup and useful functions
-packages.install("strucchange"); library(strucchange)
+packages.install("strucchange")
+library(strucchange)
 struccPlot <- function(tsData, brData, nBreak){
   # Displays chosen number of breaks on base timeseries datam with location error bars
   plot(tsData)
   lines(fitted(brData, breaks = nBreak), col = 4)
   lines(confint(brData, breaks = nBreak))
+  grid(nx = NULL, ny = NA, col = "lightgray", lty = "dotted",
+       lwd = par("lwd"))
 }
 brDates <- function(brData){
   # Takes numeric breakdates output (as e.g. 2012.25 for Apr '12) and converts to list of Month Year periods.
+  # TODO rewrite this to avoid use of added 1m shift
   brData_long <- paste("01", trunc(12*(brData %% 1)), trunc(brData), sep = " ") %>% as.Date("%d %m %Y")
-  brData_strings <- paste(month(brData_long, label = TRUE, abbr = FALSE), year(brData_long), sep = " ")
+  brData_strings <- paste(month(brData_long+months(1), label = TRUE, abbr = FALSE), year(brData_long), sep = " ") # 1m shift is a fiddle because 2012.0 = January
   print("Structural breaks occur at: ")
   return(brData_strings)
 }
 
 ## STRUCCHANGE// level breaks
-brApr_l <- breakpoints(tsAprTotal ~ 1, h = 0.1) # ~1 is LEVELS
-summary(brApr_l); plot(brApr_l)
-struccPlot(tsAprTotal, brData = brApr_l, nBreak = 4)
+brAprTotal_l <- breakpoints(tsAprTotal ~ 1, h = 0.1) # ~1 is LEVELS
+summary(brAprTotal_l); plot(brAprTotal_l)
+struccPlot(tsAprTotal, brData = brAprTotal_l, nBreak = 4)
+
 
 ## STRUCCHANGE // trend breaks
 trend_fit <- lm(tsAprTotal ~ tindex) # linear model
   summary(trend_fit) # check LR model is signif
-brApr_t <- breakpoints(tsAprTotal ~ tindex, h = 0.1) # ~t is TREND (LR)
-summary(brApr_t); plot(brApr_t) # choose nBreak for min BIC
-struccPlot(tsAprTotal, brData = brApr_t, nBreak = 2)
-brDates(breakdates(brApr_t, breaks = 2))
+brAprTotal_t <- breakpoints(tsAprTotal ~ tindex, h = 0.1) # ~ t is TREND (LR)
+summary(brAprTotal_t); plot(brAprTotal_t) # choose nBreak for min BIC
+struccPlot(tsAprTotal, brData = brAprTotal_t, nBreak = 2)
+brDates(breakdates(brAprTotal_t, breaks = 2))
+breakdates(brAprTotal_t, breaks = 2, format.times = TRUE)
+
+brAprTEW_t <- breakpoints(tsAprTEW ~ tindex, h = 0.1)
+summary(brAprTEW_t); plot(brAprTEW_t)
+struccPlot(tsAprTEW, brData = brAprTEW_t, nBreak=2)
 
 ## STRUCCHANGE // polynomial fitting breaks
 # fit to 2o polynomial using lm(tsAprTotal ~ tt + I(tt^2))

--- a/main.R
+++ b/main.R
@@ -1,17 +1,44 @@
-# Import and label data table
-aprData <- s3tools::s3_path_to_full_df("alpha-bjml-personalpractice/changeDetection/totalsApr18.csv") %>% as.tibble()
-colnames(aprData) <- c("Period", "totalTEW", "totalIO", "TOTAL")
-head(aprData)
+## Import April 18 CC data and display initial plot
+source('importData.R')
 
-library(tidyverse); library(lubridate); library(stringr)
+## TS Explore
+tsAprTotal <- ts(aprData$TOTAL, frequency = 12, start = c(2008, 1), end = c(2018, 2))
+  plot(tsAprTotal)
+dcAprTotal <- decompose(tsAprTotal, type = "additive")
+  plot(dcAprTotal)
+tindex <- 1:length(aprData$TOTAL) # index times
+fitApr <- ts(loess(aprData$TOTAL ~ tindex, span = 0.1)$fitted, frequency = 12, start = c(2008, 1))
+plot(tsAprTotal); lines(fitApr, col  = 4)
 
-# Get Period into usable date format (defaulted to start of month)
-aprData$Period <- str_c("01 ", aprData$Period)
-aprData$PeriodStart <- as.Date(aprData$Period, "%d %b-%y")
-aprData$Period <- substr(aprData$Period,4,10)
-head(aprData)
+## STRUCCHANGE // setup and useful functions
+packages.install("strucchange"); library(strucchange)
+struccPlot <- function(tsData, brData, nBreak){
+  # Displays chosen number of breaks on base timeseries datam with location error bars
+  plot(tsData)
+  lines(fitted(brData, breaks = nBreak), col = 4)
+  lines(confint(brData, breaks = nBreak))
+}
+brDates <- function(brData){
+  # Takes numeric breakdates output (as e.g. 2012.25 for Apr '12) and converts to list of Month Year periods.
+  brData_long <- paste("01", trunc(12*(brData %% 1)), trunc(brData), sep = " ") %>% as.Date("%d %m %Y")
+  brData_strings <- paste(month(brData_long, label = TRUE, abbr = FALSE), year(brData_long), sep = " ")
+  print("Structural breaks occur at: ")
+  return(brData_strings)
+}
 
-# Initial plot
-ggplot(aprData, aes(PeriodStart, TOTAL)) + 
-  geom_line() +
-  labs(x = "Date", y = "Total Trials", title ="Total Trial Volume to April 2018")
+## STRUCCHANGE// level breaks
+brApr_l <- breakpoints(tsAprTotal ~ 1, h = 0.1) # ~1 is LEVELS
+summary(brApr_l); plot(brApr_l)
+struccPlot(tsAprTotal, brData = brApr_l, nBreak = 4)
+
+## STRUCCHANGE // trend breaks
+trend_fit <- lm(tsAprTotal ~ tindex) # linear model
+  summary(trend_fit) # check LR model is signif
+brApr_t <- breakpoints(tsAprTotal ~ tindex, h = 0.1) # ~t is TREND (LR)
+summary(brApr_t); plot(brApr_t) # choose nBreak for min BIC
+struccPlot(tsAprTotal, brData = brApr_t, nBreak = 2)
+brDates(breakdates(brApr_t, breaks = 2))
+
+## STRUCCHANGE // polynomial fitting breaks
+# fit to 2o polynomial using lm(tsAprTotal ~ tt + I(tt^2))
+# (I() here just preserves class of tt as is)

--- a/monitor.R
+++ b/monitor.R
@@ -1,0 +1,54 @@
+## Exploration of 'live' monitoring using windowed data
+# How soon can we spot the big jump at March 2013?
+# Monitor through June 2012-June 2013 using 2010-2012 as history.
+windowData <- window(tsAprTotal, start = c(2010, 1), end = c(2012,5))
+tt <- 1:length(windowData)
+me.mefp <- mefp(windowData ~ tt, type = "ME", alpha = 0.05)
+
+# Now new data is added to windowData
+windowData <- window(tsAprTotal, start = c(2010, 1), end = c(2013,12))
+tt <- 1:length(windowData)
+# Monitor on each new piece
+me.mefp <- monitor(me.mefp) # By end of 2013 a change is detected
+me.mefp
+plot(me.mefp)
+as.Date(windowData)[43] # Appears to be dated July 2013 (Not Mar)
+
+# If we ran this live (point by point) each month June 2012 onwards, what would happen?
+  # Reinitialise history window 2010.1 to 2012.5
+  windowData <- window(tsAprTotal, start = c(2010, 1), end = c(2012,5))
+  tt <- 1:length(windowData)
+  me.mefp <- mefp(windowData ~ tt, type = "ME", alpha = 0.05)
+  endDate = ymd(20120501)
+  
+  # Now increase the window month by month
+for (i in 1:20){
+  endDate <- endDate + months(1)
+  newEndVec <- c(year(endDate), month(endDate))
+  windowData <- window(tsAprTotal, start = c(2010, 1), end = newEndVec) # Update windowData
+  tt <- 1:length(windowData) # Update length
+  me.mefp <- monitor(me.mefp) # Monitor on change
+  
+  if (is.na(me.mefp["breakpoint"])){
+    print(paste("[iter.",str_pad(i,2),"]", month(endDate, label = TRUE), year(endDate), "No Breakpoint Detected", sep = " "))
+    plot(me.mefp)
+  } else {
+    print(paste("[iter.",str_pad(i,2),"]", month(endDate, label = TRUE), year(endDate), "Breakpoint Detected at", as.Date(windowData)[as.numeric(me.mefp["breakpoint"])], sep = " "))
+    plot(me.mefp)
+    break
+  }
+}
+
+
+## Monitoring of FIRST DIFFS (rubbish)
+dwindowData <- window(tsAprTotal, start = c(2010, 1), end = c(2012,5)) %>% diff()
+plot(dwindowData)
+tt <- 1:length(dwindowData)
+me.mefp <- mefp(dwindowData ~ tt, type = "ME", alpha = 0.05)
+
+dwindowData <- window(tsAprTotal, start = c(2010, 1), end = c(2013,12)) %>% diff()
+plot(dwindowData)
+tt <- 1:length(dwindowData)
+me.mefp <- monitor(me.mefp)
+me.mefp
+plot(me.mefp)


### PR DESCRIPTION
Master now centres on `strucchange` as incumbent method used with April 18 timeseries data for range of offence types and summary statistics (e.g. total TEW trials, total appeals). To be compared to simple manual detection routines.